### PR TITLE
Add capybara

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openaustralia/morph-base
 MAINTAINER Matthew Landauer <matthew@oaf.org.au>
 
 # libcurl is needed by typhoeus gem
-RUN apt-get -y install curl libxslt-dev libxml2-dev libcurl4-gnutls-dev poppler-utils
+RUN apt-get -y install curl libxslt-dev libxml2-dev libcurl4-gnutls-dev poppler-utils libqt4-dev
 
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /etc/bash.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openaustralia/morph-base
 MAINTAINER Matthew Landauer <matthew@oaf.org.au>
 
 # libcurl is needed by typhoeus gem
-RUN apt-get -y install curl libxslt-dev libxml2-dev libcurl4-gnutls-dev poppler-utils libqt4-dev
+RUN apt-get -y install curl libxslt-dev libxml2-dev libcurl4-gnutls-dev poppler-utils libqt4-dev xvfb
 
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /etc/bash.bashrc

--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,7 @@ gem "unix_utils", "0.0.14"
 gem "upsert", "0.3.4"
 gem "uuidtools", "2.1.3"
 gem "webrobots", "0.0.12"
+
+
+gem "capybara", "2.0.3"
+gem "capybara-webkit", "1.3.0"


### PR DESCRIPTION
For javascript heavy sites; having something that speaks javascript is a lot easier than mechanize. As a proof of concept, I got an odesker to rewrite the failing hobart scraper using capybara webkit - 
https://morph.io/CloCkWeRX/hobart-capybara-webkit

This site unfortunately used a lot of javascript to re-invent hyperlinks.
If this works, similar things can be done for Kingston, Adelaide, Port Adelaide-Enfield and many more ePathway based sites.

I really am not too sure how docker works; so this is completely untested(!), but I've added the relevant gems and dependencies.

The one remaining part is doing something like
`xvfb-run -a ruby scraper.rb` - see https://github.com/thoughtbot/capybara-webkit#ci

... where it wasn't clear what the appropriate spot was.
